### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ example_projects/test_project/**
 bp_dev
 bp
 build_report.json
+
+# Nix.
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697730408,
+        "narHash": "sha256-Ww//zzukdTrwTrCUkaJA/NsaLEfUfQpWZXBdXBYfhak=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ff0a5a776b56e0ca32d47a4a47695452ec7f7d80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "A development tool for running commands with maximum possible concurrency.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pname = "build_pipeline";
+      version = "0.0.14";
+
+      pkgs = import nixpkgs {inherit system;};
+      beamPackages = pkgs.beam.packages.erlang_25;
+      elixir = beamPackages.elixir_1_14;
+      hex = beamPackages.hex;
+    in {
+      # `nix develop`.
+      devShells = {
+        default = pkgs.mkShell {
+          packages = [
+            elixir
+          ];
+        };
+      };
+      # `nix fmt`.
+      formatter = pkgs.alejandra;
+      # `nix build`.
+      packages = {
+        build-pipeline = pkgs.stdenvNoCC.mkDerivation {
+          inherit pname version;
+          src = pkgs.nix-gitignore.gitignoreSource [] ./.;
+          nativeBuildInputs = [elixir pkgs.makeWrapper];
+          buildPhase = ''
+            # Expose Nix's hex to Mix.
+            export MIX_PATH="${hex}/lib/erlang/lib/hex/ebin"
+            export HOME=$PWD/.hex
+            mkdir -p $HOME
+            mix deps.get
+            env MIX_ENV=prod mix escript.build
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp bp $out/bin/bp
+            wrapProgram $out/bin/bp \
+              --prefix PATH : ${pkgs.lib.makeBinPath [beamPackages.erlang]}
+          '';
+        };
+        default = self.packages.${system}.build-pipeline;
+      };
+    });
+}


### PR DESCRIPTION
Similar in spirit to https://github.com/Multiverse-io/anonymiser/pull/125, this adds a Nix flake to build_pipeline to address [sc-34402](https://app.shortcut.com/multiverse/story/34402/add-nix-flake-to-build-pipeline). The flake provdes:

- A development environment providing Elixir, automatically activated for direnv users or manually activated with `nix develop`.
- A package output which can be generated with `nix build` (executable placed in `result/bin/bp`) and consumed by other flakes, for example see https://github.com/Multiverse-io/platform/commit/94d8d3efca18ab40ee3b3b8bffe06190b34161a4#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R28-R31.

The pros, cons, and to-dos from https://github.com/Multiverse-io/anonymiser/pull/125 apply here.