### PR TITLE
Add CI to verify Nix build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lints:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      # Verify that we can build the escript from the flake.
+      # This is primarily a test of the Mix dependencies hash being up-to-date
+      # in the flake.
+      - run: nix build .


### PR DESCRIPTION
Because other projects depend on the ability for our flake to be build-able, it seems sensible to check build-ability in the CI.

I used GitHub actions because it's easier for me to write.